### PR TITLE
Fix global objcopy

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/sii_eeprom.o
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/sii_eeprom.bin
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  COMMAND arm-none-eabi-objcopy -I binary -O elf32-littlearm -B arm sii_eeprom.bin ${CMAKE_CURRENT_BINARY_DIR}/sii_eeprom.o
+  COMMAND ${CMAKE_OBJCOPY} -I binary -O elf32-littlearm -B arm sii_eeprom.bin ${CMAKE_CURRENT_BINARY_DIR}/sii_eeprom.o
   )
 
 add_executable(${CMAKE_PROJECT_NAME}


### PR DESCRIPTION
When arm-objcopy is not globally installed it's better to use CMAKE_OBJCOPY